### PR TITLE
support two-arg (explicit named) version of passport.use

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,12 @@
 module.exports = function(chai, _) {
   var Test = require('./test');
-  
+
   chai.passport = chai.passport || {};
-  chai.passport.use = function(strategy) {
+  chai.passport.use = function(name, strategy) {
+		if (!strategy) {
+			strategy = name;
+			name = strategy.name;
+		}
     return new Test(strategy);
   };
 };


### PR DESCRIPTION
Passport has a two-argument version of `passport.use` which takes an explicit name for the strategy, and unfortunately puts the name first (so that it overrides the `passport.use(strategy)` use of the function). This has the `chat-passport-strategy`'s implementation of `.use` support that use.

Of note, it [uses the exact code that Passport itself uses to implement the two-argument form](https://github.com/jaredhanson/passport/blob/217018dbc46dcd4118dd6f2c60c8d97010c587f8/lib/authenticator.js#L58-L61).

This PR doesn't contain any test case, since the original test suite doesn't have a test for the `.use` function itself.